### PR TITLE
Minor bugfixes, improved plugin reload & lore formatting

### DIFF
--- a/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
+++ b/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
@@ -63,7 +63,7 @@ public class UltimateCatcher extends SongodaPlugin {
 
         // Setup Config
         Settings.setupConfig();
-        this.setLocale(Settings.LANGUGE_MODE.getString(), false);
+        this.setLocale(Settings.LANGUAGE_MODE.getString(), false);
 
         // Set economy preference
         EconomyManager.getManager().setPreferredHook(Settings.ECONOMY_PLUGIN.getString());
@@ -183,7 +183,7 @@ public class UltimateCatcher extends SongodaPlugin {
 
     @Override
     public void onConfigReload() {
-        this.setLocale(Settings.LANGUGE_MODE.getString(), true);
+        this.setLocale(Settings.LANGUAGE_MODE.getString(), true);
     }
 
     @Override

--- a/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
+++ b/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
@@ -154,22 +154,7 @@ public class UltimateCatcher extends SongodaPlugin {
         eggConfig.load();
         eggConfig.saveChanges();
 
-        /*
-         * Register eggs into EggManager from Configuration.
-         */
-        if (eggConfig.contains("Eggs")) {
-            for (String keyName : eggConfig.getConfigurationSection("Eggs").getKeys(false)) {
-                ConfigurationSection section = eggConfig.getConfigurationSection("Eggs." + keyName);
-
-                EggBuilder eggBuilder = new EggBuilder(keyName)
-                        .setName(section.getString("Name"))
-                        .setRecipe(section.getStringList("Recipe"))
-                        .setCost(section.getDouble("Cost"))
-                        .setChance(Integer.parseInt(section.getString("Chance").replace("%", "")));
-
-                eggManager.addEgg(eggBuilder.build());
-            }
-        }
+        eggManager.loadEggs();
     }
 
     @Override
@@ -185,6 +170,9 @@ public class UltimateCatcher extends SongodaPlugin {
     public void onConfigReload() {
         this.setLocale(Settings.LANGUAGE_MODE.getString(), true);
         this.mobConfig.load();
+
+        this.eggConfig.load();
+        this.eggManager.loadEggs();
     }
 
     @Override

--- a/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
+++ b/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
@@ -184,6 +184,7 @@ public class UltimateCatcher extends SongodaPlugin {
     @Override
     public void onConfigReload() {
         this.setLocale(Settings.LANGUAGE_MODE.getString(), true);
+        this.mobConfig.load();
     }
 
     @Override

--- a/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
+++ b/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
@@ -206,4 +206,8 @@ public class UltimateCatcher extends SongodaPlugin {
     public Config getMobConfig() {
         return mobConfig;
     }
+
+    public Config getEggConfig() {
+        return eggConfig;
+    }
 }

--- a/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
+++ b/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
@@ -126,7 +126,6 @@ public class UltimateCatcher extends SongodaPlugin {
                 if (Bukkit.getRecipe(shapelessRecipe.getKey()) == null) {
                     Bukkit.addRecipe(shapelessRecipe);
                     this.registeredRecipes.add(shapelessRecipe.getKey());
-                    Bukkit.getLogger().info("Registered recipe " + shapelessRecipe.getKey().getKey());
                 } else
                     Bukkit.getLogger().warning("Recipe " + shapelessRecipe.getKey().getKey() + " is already registered.");
             }

--- a/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
+++ b/src/main/java/com/songoda/ultimatecatcher/UltimateCatcher.java
@@ -103,11 +103,14 @@ public class UltimateCatcher extends SongodaPlugin {
                 ShapelessRecipe shapelessRecipe = ServerVersion.isServerVersionAtLeast(ServerVersion.V1_12)
                         ? new ShapelessRecipe(new NamespacedKey(this, egg.getKey()),
                         egg.toItemStack()) : new ShapelessRecipe(egg.toItemStack());
+
                 for (String item : egg.getRecipe()) {
                     String[] split = item.split(":");
-                    shapelessRecipe.addIngredient(Integer.valueOf(split[0]), Material.valueOf(split[1]));
+                    shapelessRecipe.addIngredient(Integer.parseInt(split[0]), Material.valueOf(split[1]));
                 }
-                Bukkit.addRecipe(shapelessRecipe);
+
+                if (Bukkit.getRecipe(shapelessRecipe.getKey()) == null)
+                    Bukkit.addRecipe(shapelessRecipe);
             }
         }
     }

--- a/src/main/java/com/songoda/ultimatecatcher/egg/CEgg.java
+++ b/src/main/java/com/songoda/ultimatecatcher/egg/CEgg.java
@@ -1,18 +1,18 @@
 package com.songoda.ultimatecatcher.egg;
 
 import com.songoda.core.compatibility.CompatibleMaterial;
-import com.songoda.core.compatibility.ServerVersion;
+import com.songoda.core.locale.Message;
 import com.songoda.core.nms.NmsManager;
 import com.songoda.core.nms.nbt.NBTItem;
 import com.songoda.core.utils.TextUtils;
 import com.songoda.ultimatecatcher.UltimateCatcher;
-import org.bukkit.Material;
+import com.songoda.ultimatecatcher.settings.Settings;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class CEgg {
 
@@ -32,13 +32,18 @@ public class CEgg {
         ItemMeta meta = item.getItemMeta();
         meta.setDisplayName(TextUtils.formatText(name));
 
-        // ToDo: Translate this.
-        List<String> lore = new ArrayList<>();
-        lore.add(UltimateCatcher.getInstance().getLocale().getMessage("general.catcher.lorecost")
-                .processPlaceholder("cost", cost).getMessage());
+        String costLine = UltimateCatcher.getInstance().getLocale().getMessage("general.catcher.lorecost")
+                .processPlaceholder("cost", cost)
+                .getMessage();
 
-        lore.add(UltimateCatcher.getInstance().getLocale().getMessage("general.catcher.lorechance")
-                .processPlaceholder("chance", chance).getMessage());
+        String chanceLine = UltimateCatcher.getInstance().getLocale().getMessage("general.catcher.lorechance")
+                .processPlaceholder("chance", chance)
+                .getMessage();
+
+        List<String> lore = Settings.CATCHER_LORE_FORMAT.getStringList().stream()
+                .map(line -> new Message(line).processPlaceholder("cost", costLine).processPlaceholder("chance", chanceLine).getMessage())
+                .collect(Collectors.toList());
+
         meta.setLore(lore);
 
         item.setItemMeta(meta);

--- a/src/main/java/com/songoda/ultimatecatcher/egg/EggManager.java
+++ b/src/main/java/com/songoda/ultimatecatcher/egg/EggManager.java
@@ -1,11 +1,39 @@
 package com.songoda.ultimatecatcher.egg;
 
+import com.songoda.core.configuration.Config;
+import com.songoda.ultimatecatcher.UltimateCatcher;
+import org.bukkit.configuration.ConfigurationSection;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 
 public class EggManager {
 
     private final Deque<CEgg> registeredEggs = new ArrayDeque<>();
+
+    /*
+     * Register eggs into EggManager from Configuration.
+     */
+    public void loadEggs() {
+        this.registeredEggs.clear();
+
+        Config eggConfig = UltimateCatcher.getInstance().getEggConfig();
+
+        if (!eggConfig.contains("Eggs"))
+            return;
+
+        for (String keyName : eggConfig.getConfigurationSection("Eggs").getKeys(false)) {
+            ConfigurationSection section = eggConfig.getConfigurationSection("Eggs." + keyName);
+
+            EggBuilder eggBuilder = new EggBuilder(keyName)
+                    .setName(section.getString("Name"))
+                    .setRecipe(section.getStringList("Recipe"))
+                    .setCost(section.getDouble("Cost"))
+                    .setChance(Integer.parseInt(section.getString("Chance").replace("%", "")));
+
+            addEgg(eggBuilder.build());
+        }
+    }
 
     public CEgg addEgg(CEgg egg) {
         registeredEggs.add(egg);

--- a/src/main/java/com/songoda/ultimatecatcher/listeners/EntityListeners.java
+++ b/src/main/java/com/songoda/ultimatecatcher/listeners/EntityListeners.java
@@ -177,6 +177,8 @@ public class EntityListeners implements Listener {
 
         String[] split = egg.getCustomName().split(";");
 
+        if (split.length < 2) return;
+
         CEgg catcher = plugin.getEggManager().getEgg(split[1]);
 
         if (catcher == null) return;

--- a/src/main/java/com/songoda/ultimatecatcher/settings/Settings.java
+++ b/src/main/java/com/songoda/ultimatecatcher/settings/Settings.java
@@ -37,6 +37,14 @@ public class Settings {
             "The enabled language file.",
             "More language files (if available) can be found in the plugins data folder.");
 
+    public static final ConfigSetting CATCHER_LORE_FORMAT = new ConfigSetting(config, "Lore Formats.Catcher.Lore", Arrays.asList("%chance%", "%cost%"),
+            "Configure the order of lines in the catcher lore.",
+            "Placeholders will get replaced with lines from the language file.");
+
+    public static final ConfigSetting CATCHER_CAUGHT_LORE_FORMAT = new ConfigSetting(config, "Lore Formats.Catcher Caught.Lore", Arrays.asList("%type%", "%age%", "%health%", "%tamed%", "%trusted%"),
+            "Configure the order of lines in a spawn egg.",
+            "Placeholders will get replaced with lines from the language file.");
+
 
     /**
      * In order to set dynamic economy comment correctly, this needs to be

--- a/src/main/java/com/songoda/ultimatecatcher/settings/Settings.java
+++ b/src/main/java/com/songoda/ultimatecatcher/settings/Settings.java
@@ -33,7 +33,7 @@ public class Settings {
             "Which economy plugin should be used?",
             "Supported plugins you have installed: \"" + EconomyManager.getManager().getRegisteredPlugins().stream().collect(Collectors.joining("\", \"")) + "\".");
 
-    public static final ConfigSetting LANGUGE_MODE = new ConfigSetting(config, "System.Language Mode", "en_US",
+    public static final ConfigSetting LANGUAGE_MODE = new ConfigSetting(config, "System.Language Mode", "en_US",
             "The enabled language file.",
             "More language files (if available) can be found in the plugins data folder.");
 

--- a/src/main/java/com/songoda/ultimatecatcher/tasks/EggTrackingTask.java
+++ b/src/main/java/com/songoda/ultimatecatcher/tasks/EggTrackingTask.java
@@ -4,6 +4,7 @@ import com.songoda.core.compatibility.CompatibleMaterial;
 import com.songoda.core.compatibility.CompatibleParticleHandler;
 import com.songoda.core.compatibility.CompatibleSound;
 import com.songoda.core.nms.NmsManager;
+import com.songoda.core.nms.nbt.NBTItem;
 import com.songoda.ultimatecatcher.UltimateCatcher;
 import com.songoda.ultimatecatcher.utils.EntityUtils;
 import com.songoda.ultimatecatcher.utils.OldEntityUtils;
@@ -69,8 +70,13 @@ public class EggTrackingTask extends BukkitRunnable {
                 // Couldn't spawn
                 if (entity == null) {
                     plugin.getEntityListeners().getEggs().remove(item.getUniqueId());
+
                     item.getItemStack().removeEnchantment(Enchantment.ARROW_KNOCKBACK);
                     item.setPickupDelay(1);
+
+                    NBTItem newItem = NmsManager.getNbt().of(item.getItemStack());
+                    newItem.remove("UCI");
+                    item.setItemStack(newItem.finish());
                     continue;
                 }
 

--- a/src/main/java/com/songoda/ultimatecatcher/tasks/EggTrackingTask.java
+++ b/src/main/java/com/songoda/ultimatecatcher/tasks/EggTrackingTask.java
@@ -3,14 +3,12 @@ package com.songoda.ultimatecatcher.tasks;
 import com.songoda.core.compatibility.CompatibleMaterial;
 import com.songoda.core.compatibility.CompatibleParticleHandler;
 import com.songoda.core.compatibility.CompatibleSound;
-import com.songoda.core.compatibility.ServerVersion;
 import com.songoda.core.nms.NmsManager;
 import com.songoda.ultimatecatcher.UltimateCatcher;
 import com.songoda.ultimatecatcher.utils.EntityUtils;
 import com.songoda.ultimatecatcher.utils.OldEntityUtils;
 import org.bukkit.ChatColor;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -56,7 +54,7 @@ public class EggTrackingTask extends BukkitRunnable {
 
                 Entity entity;
                 if (NmsManager.getNbt().of(item.getItemStack()).has("serialized_entity")) {
-                    entity = EntityUtils.spawnEntity(inWater ? item.getLocation().getBlock().getLocation().add(.5,.5,.5)
+                    entity = EntityUtils.spawnEntity(inWater ? item.getLocation().getBlock().getLocation().add(.5, .5, .5)
                             : item.getLocation(), item.getItemStack());
                 } else if (!displayName.contains("~") && NmsManager.getNbt().of(item.getItemStack()).has("UCI")) {
                     entity = OldEntityUtils.spawnEntity(item.getLocation(), item.getItemStack());
@@ -66,10 +64,19 @@ public class EggTrackingTask extends BukkitRunnable {
                     entity = OldEntityUtils.spawnEntity(item.getLocation(), json);
                 }
 
-                CompatibleParticleHandler.spawnParticles(CompatibleParticleHandler.ParticleType.SMOKE_NORMAL, entity.getLocation(), 100, .5, .5, .5);
-                CompatibleSound.ITEM_FIRECHARGE_USE.play(entity.getWorld(), entity.getLocation(),1L, 1L);
-
                 eggs.remove(item);
+
+                // Couldn't spawn
+                if (entity == null) {
+                    plugin.getEntityListeners().getEggs().remove(item.getUniqueId());
+                    item.getItemStack().removeEnchantment(Enchantment.ARROW_KNOCKBACK);
+                    item.setPickupDelay(1);
+                    continue;
+                }
+
+                CompatibleParticleHandler.spawnParticles(CompatibleParticleHandler.ParticleType.SMOKE_NORMAL, entity.getLocation(), 100, .5, .5, .5);
+                CompatibleSound.ITEM_FIRECHARGE_USE.play(entity.getWorld(), entity.getLocation(), 1L, 1L);
+
                 item.remove();
             }
         }


### PR DESCRIPTION
- when an egg attempts to spawn a mob where spawning is denied (WorldGuard, Residence, world settings..) make it pickable again (related stacktrace: https://hastebin.com/ujuvamidix.bash)

- when custom name on an egg is not valid, return (related stacktrace: https://hastebin.com/ugayibajos.sql)

- eggconfig & mobconfig now reload on plugin reload, properly register recipes and eggs (moved egg loading into EggManager, seems to me like a better place to keep this method)

- added lore formatting into config (change the order of lines in catchers & spawn eggs, found the to-do and wanted to do it anyway)